### PR TITLE
fix some bugs.

### DIFF
--- a/torchdrug/data/dataset.py
+++ b/torchdrug/data/dataset.py
@@ -126,7 +126,7 @@ class MoleculeDataset(torch_data.Dataset, core.Configurable):
         return index
 
     def get_item(self, index):
-        if self.lazy:
+        if hasattr(self, 'lazy') and self.lazy:
             item = {"graph": data.Molecule.from_smiles(self.smiles_list[index], **self.kwargs)}
         else:
             item = {"graph": self.data[index]}

--- a/torchdrug/tasks/retrosynthesis.py
+++ b/torchdrug/tasks/retrosynthesis.py
@@ -352,7 +352,7 @@ class SynthonCompletion(tasks.Task, core.Configurable):
             dataset = train_set.dataset
         else:
             dataset = train_set
-        self.dataset_kwargs = dataset.config_dict()["kwargs"]
+        self.dataset_kwargs = dataset.config_dict().get("kwargs")
 
         node_dim = self.model.output_dim
         edge_dim = 0


### PR DESCRIPTION
when I run these codes
`synthon_dataset = datasets.USPTO50k("./molecule-dataset/", as_synthon=True,
                                    node_feature="synthon_completion",
                                    kekulize=True)`
`sample = synthon_dataset[0]`

the function `get_item(self, index)` will raise an error `AttributeError: 'USPTO50k' object has no attribute 'lazy'`, so here should be a check for the presence of attribute `lazy`