### PR TITLE
Speedup dataset lazy loading

### DIFF
--- a/torchdrug/data/dataset.py
+++ b/torchdrug/data/dataset.py
@@ -57,12 +57,13 @@ class MoleculeDataset(torch_data.Dataset, core.Configurable):
 
         if verbose:
             smiles_list = tqdm(smiles_list, "Constructing molecules from SMILES")
+        
         for i, smiles in enumerate(smiles_list):
-            mol = Chem.MolFromSmiles(smiles)
-            if not mol:
-                logger.debug("Can't construct molecule from SMILES `%s`. Ignore this sample." % smiles)
-                continue
             if not self.lazy or len(self.data) == 0:
+                mol = Chem.MolFromSmiles(smiles)
+                if not mol:
+                    logger.debug("Can't construct molecule from SMILES `%s`. Ignore this sample." % smiles)
+                    continue
                 mol = data.Molecule.from_molecule(mol, **kwargs)
             else:
                 mol = None

--- a/torchdrug/datasets/zinc2m.py
+++ b/torchdrug/datasets/zinc2m.py
@@ -36,9 +36,10 @@ class ZINC2m(data.MoleculeDataset):
             os.makedirs(path)
         zip_file_name = utils.download(self.url, path, md5=self.md5)
 
-        save_file = utils.extract(zip_file=zip_file_name, member=self.member)
         neo_save_file = os.path.join(os.path.dirname(zip_file_name), 'zinc2m_'+os.path.basename(self.member))
-        shutil.move(save_file, neo_save_file)
+        if not os.path.exists(neo_save_file):
+            save_file = utils.extract(zip_file=zip_file_name, member=self.member)
+            shutil.move(save_file, neo_save_file)
 
         with open(neo_save_file, "r") as fin:
             reader = csv.reader(fin)


### PR DESCRIPTION
1. `MoleculeDataset(lazy=True)` converts a smile to an `rdkit` `Mol` object and overwrites it with `None`. Loading large datasets like ZINC2m is severely slowed down by this, so avoid the unnecessary conversion to a `Mol` when `lazy=True`
2. Check download/extract logic with ZINC2m dataset to avoid redundancy and conflicts.