### PR TITLE
Redesign of the meter logger and integration of the Weights and Biases logger

### DIFF
--- a/torchdrug/core/engine.py
+++ b/torchdrug/core/engine.py
@@ -59,7 +59,7 @@ class Engine(core.Configurable):
     """
 
     def __init__(self, task, train_set, valid_set, test_set, optimizer, scheduler=None, gpus=None, batch_size=1,
-                 gradient_interval=1, num_worker=0, log_interval=100, metric_logger='simple', project=None):
+                 gradient_interval=1, num_worker=0, log_interval=100, metric_logger='console', project=None):
         self.rank = comm.get_rank()
         self.world_size = comm.get_world_size()
         self.gpus = gpus
@@ -114,10 +114,14 @@ class Engine(core.Configurable):
             if not key.startswith("_"):
                 hyperparams[key] = val
         hyperparams.update({'model_type': self.model.model.__class__.__name__})
+        hyperparams.update({'task': self.model.__class__.__name__})
         self.meter.logger.save_hyperparams(hyperparams)
 
         if isinstance(self.meter.logger, WandbLogger):
-            self.meter.logger.watch(self.model.model)
+            try:
+                self.meter.logger.watch(self.model.model)
+            except:
+                logger.warning("The given model cannot be watched by wandb")
 
     def train(self, num_epoch=1, batch_per_epoch=None):
         """

--- a/torchdrug/core/engine.py
+++ b/torchdrug/core/engine.py
@@ -54,6 +54,8 @@ class Engine(core.Configurable):
             This creates an equivalent batch size of ``batch_size * gradient_interval`` for optimization.
         num_worker (int, optional): number of CPU workers per GPU
         log_interval (int, optional): log every n gradient updates
+        metric_logger (str or torchdrug.utils.loggers.BaseLogger, optional): logger for the metrics
+        project (str, optional): project for which metrics are being logged
     """
 
     def __init__(self, task, train_set, valid_set, test_set, optimizer, scheduler=None, gpus=None, batch_size=1,

--- a/torchdrug/utils/loggers/__init__.py
+++ b/torchdrug/utils/loggers/__init__.py
@@ -1,2 +1,2 @@
-from torchdrug.utils.loggers.simple_logger import SimpleLogger
+from torchdrug.utils.loggers.console_logger import ConsoleLogger
 from torchdrug.utils.loggers.wandb_logger import WandbLogger

--- a/torchdrug/utils/loggers/__init__.py
+++ b/torchdrug/utils/loggers/__init__.py
@@ -1,1 +1,2 @@
 from torchdrug.utils.loggers.simple_logger import SimpleLogger
+from torchdrug.utils.loggers.wandb_logger import WandbLogger

--- a/torchdrug/utils/loggers/__init__.py
+++ b/torchdrug/utils/loggers/__init__.py
@@ -1,0 +1,1 @@
+from torchdrug.utils.loggers.simple_logger import SimpleLogger

--- a/torchdrug/utils/loggers/base_logger.py
+++ b/torchdrug/utils/loggers/base_logger.py
@@ -7,19 +7,23 @@ import torch
 
 
 class BaseLogger(ABC):
-    def __init__(self, logger_interval=100):
+    def __init__(self, log_interval=100):
         self.records = defaultdict(list)
         self.epoch_id = 0
         self.batch_id = 0
         self.epoch2batch = [0]
-        self.logger_interval = logger_interval
+        self.log_interval = log_interval
     
     @abstractmethod
-    def log(self, record):
+    def log(self, record, type='train'):
+        pass
+
+    @abstractmethod
+    def save_hyperparams(self, hyperparams):
         pass
 
     def update(self, record):
-        if self.batch_id % self.logger_interval == 0:
+        if self.batch_id % self.log_interval == 0:
             self.log(record)
         self.batch_id += 1
 
@@ -36,5 +40,5 @@ class BaseLogger(ABC):
         averages = {}
         for k in sorted(self.records.keys()):
             averages[f"average {k}"] = np.mean(self.records[k][index])
-        
+        averages['epoch'] = self.epoch_id
         self.log(averages)

--- a/torchdrug/utils/loggers/base_logger.py
+++ b/torchdrug/utils/loggers/base_logger.py
@@ -8,6 +8,17 @@ import torch
 
 class BaseLogger(ABC):
     def __init__(self, log_interval=100):
+        """
+        Abstract class that handles all the logging for the corresponding run.
+        This class can be inherited to implement different logging methods.
+
+        ..code-block:: python
+            class NewLogger(BaseLogger):
+                pass
+        
+        Parameters:
+            log_interval (int, optional): log after every n steps
+        """
         self.records = defaultdict(list)
         self.epoch_id = 0
         self.batch_id = 0
@@ -16,13 +27,34 @@ class BaseLogger(ABC):
     
     @abstractmethod
     def log(self, record, type='train'):
+        """
+        Log a record.
+        This is implemented differently by each new logger.
+
+        Parameters:
+            record (dict): any tensor metric
+            type (str, optional): type of record (train or valid or test)
+        """
         pass
 
     @abstractmethod
     def save_hyperparams(self, hyperparams):
+        """
+        Log the hyperparameters.
+        This is implemented differently by each new logger.
+
+        Parameters:
+            hyperparams (dict): hyperparameters
+        """
         pass
 
     def update(self, record):
+        """
+        Update with a meter record.
+
+        Parameters:
+            record (dict): any tensor metric
+        """
         if self.batch_id % self.log_interval == 0:
             self.log(record)
         self.batch_id += 1
@@ -33,6 +65,10 @@ class BaseLogger(ABC):
             self.records[k].append(v)
     
     def step(self):
+        """
+        Step an epoch for the logger.
+        Log the averages of all the metrics calculated during the epoch.
+        """
         self.epoch_id += 1
         self.epoch2batch.append(self.batch_id)
         index = slice(self.epoch2batch[-2], self.epoch2batch[-1])

--- a/torchdrug/utils/loggers/base_logger.py
+++ b/torchdrug/utils/loggers/base_logger.py
@@ -1,0 +1,41 @@
+import time
+from abc import ABC, abstractmethod
+from collections import defaultdict
+
+import numpy as np
+import torch
+
+
+class BaseLogger(ABC):
+    def __init__(self, logger_interval=100):
+        self.records = defaultdict(list)
+        self.epoch_id = 0
+        self.batch_id = 0
+        self.epoch2batch = [0]
+        self.logger_interval = logger_interval
+    
+    @abstractmethod
+    def log(self, record):
+        pass
+
+    def update(self, record):
+        if self.batch_id % self.logger_interval == 0:
+            self.log(record)
+        self.batch_id += 1
+
+        for k, v in record.items():
+            if isinstance(v, torch.Tensor):
+                v = v.item()
+            self.records[k].append(v)
+    
+    def step(self):
+        self.epoch_id += 1
+        self.epoch2batch.append(self.batch_id)
+        index = slice()
+        index = slice(self.epoch2batch[-2], self.epoch2batch[-1])
+
+        averages = {}
+        for k in sorted(self.records.keys()):
+            averages[f"average {k}"] = np.mean(self.records[k][index])
+        
+        self.log(averages)

--- a/torchdrug/utils/loggers/console_logger.py
+++ b/torchdrug/utils/loggers/console_logger.py
@@ -4,8 +4,15 @@ from torchdrug.utils import pretty
 from torchdrug.utils.loggers.base_logger import BaseLogger
 
 
-class SimpleLogger(BaseLogger):
+class ConsoleLogger(BaseLogger):
     def __init__(self, log_interval=100):
+        """
+        Implementation of the original logger in TorchDrug conforming to the new logging architecture.
+        It inherits from the BaseLogger class and implements the log and save_hyperparams methods.
+
+        Parameters:
+            log_interval (int, optional): log after every n steps
+        """
         super().__init__(log_interval=log_interval)
         self.logger = logging.getLogger(__name__)
     

--- a/torchdrug/utils/loggers/simple_logger.py
+++ b/torchdrug/utils/loggers/simple_logger.py
@@ -1,0 +1,16 @@
+import logging
+
+from torchdrug.utils import pretty
+from torchdrug.utils.loggers.base_logger import BaseLogger
+
+
+class SimpleLogger(BaseLogger):
+    def __init__(self):
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+    
+    def log(self, record):
+        self.logger.warning(pretty.separator)
+
+        for k in sorted(record.keys()):
+            self.logger.warning("%s: %g" % (k, record[k]))

--- a/torchdrug/utils/loggers/simple_logger.py
+++ b/torchdrug/utils/loggers/simple_logger.py
@@ -5,12 +5,17 @@ from torchdrug.utils.loggers.base_logger import BaseLogger
 
 
 class SimpleLogger(BaseLogger):
-    def __init__(self, logger_interval=100):
-        super().__init__(logger_interval=logger_interval)
+    def __init__(self, log_interval=100):
+        super().__init__(log_interval=log_interval)
         self.logger = logging.getLogger(__name__)
     
-    def log(self, record):
+    def save_hyperparams(self, hyperparams):
+        self.logger.warning(pretty.separator)
+        for k in sorted(hyperparams.keys()):
+            self.logger.warning("%s: %s" % (k, hyperparams[k]))
+
+    def log(self, record, type='train'):
         self.logger.warning(pretty.separator)
 
         for k in sorted(record.keys()):
-            self.logger.warning("%s: %g" % (k, record[k]))
+            self.logger.warning("%s %s: %g" % (type, k, record[k]))

--- a/torchdrug/utils/loggers/wandb_logger.py
+++ b/torchdrug/utils/loggers/wandb_logger.py
@@ -10,6 +10,16 @@ except ImportError:
 
 class WandbLogger(BaseLogger):
     def __init__(self, project=None, name=None, save_dir=None, log_interval=100, **kwargs):
+        """
+        Implementation of the W&B logger in TorchDrug.
+        It inherits from the BaseLogger class and implements the log and save_hyperparams methods.
+
+        Parameters:
+            project (str, optional): Name of the wandb project
+            name (str, optional): Name of the wandb run
+            save_dir (str, optional): Directory to save the wandb run
+            log_interval (int, optional): log after every n steps
+        """
         if wandb is None:
             raise ModuleNotFoundError(
                 "You want to use `wandb` logger which is not installed yet,"
@@ -27,6 +37,8 @@ class WandbLogger(BaseLogger):
 
         _ = self.experiment
 
+        # We define an epoch as a metric so that the averages logged
+        # at the end of the epoch are plotted against the epochs
         self.experiment.define_metric("epoch")
         self.experiment.define_metric("average/*", step_metric="epoch")
     


### PR DESCRIPTION
## Feature

This pull request consists of a redesign of the meter logger.
There is a new abstract `BaseLogger` class in `torchdrug.utils.loggers.base_logger`. The `update` and `log` functions of the `core.Meter` class are now implemented as methods of this class and are called inside the `core.Meter` methods.

For a new logger, there are 2 abstract methods in `BaseLogger`: `log` and `save_hyperparams`. These two have to be defined for a new custom logger.

The `ConsoleLogger` is a child of the `BaseLogger` class and performs the logging as being done currently in TorchDrug. The ConsoleLogger is always on irrespective if another logger is being used or not.

Similarly, the `WandbLogger` is also a child of `BaseLogger` and logs all the metrics to the user's W&B account. The `wandb` package is not a dependency and if a user tries to use the `WandbLogger` without installing wandb, they are prompted to install it. 

The constructor of `core.Engine` is updated to take two more optional arguments:
- metric_logger: This can be a str or an instance of the custom logger. The accepted str arguments currently are 'wandb' and 'console' (default value is 'console')
- project: The name of the W&B project the user wants to log to (default value is None)

Example:
  ```
  engine = core.Engine(...,  metric_logger='wandb', project='PropertyPrediction')
  ```
  or
  ```
   from torchdrug.utils.logger.wandb_logger import WandbLogger
   wandb_logger = WandbLogger(project="PropertyPrediction", name="Toxicity Prediction", save_dir="./ClinTox", log_interval=10)
  engine = core.Engine(..., metric_logger=wandb_logger)
  ```

A couple of runs for different tasks logged to W&B
- https://wandb.ai/manan-goel/TorchDrug-Generation
- https://wandb.ai/manan-goel/TorchDrug-Pretrain
- https://wandb.ai/manan-goel/TorchDrug-PropertyPrediction