### PR TITLE
fix: RuntimeError if batch has only invalid mols

### DIFF
--- a/torchdrug/data/graph.py
+++ b/torchdrug/data/graph.py
@@ -1219,7 +1219,7 @@ class PackedGraph(Graph):
 
         index = self._standarize_index(index[0], self.batch_size)
         count = index.bincount(minlength=self.batch_size)
-        if count.max() > 1:
+        if len(count) > 0 and max(count) > 1:
             graph = self.repeat_interleave(count)
             index_order = index.argsort()
             order = torch.zeros_like(index)

--- a/torchdrug/data/graph.py
+++ b/torchdrug/data/graph.py
@@ -1219,7 +1219,7 @@ class PackedGraph(Graph):
 
         index = self._standarize_index(index[0], self.batch_size)
         count = index.bincount(minlength=self.batch_size)
-        if len(count) > 0 and max(count) > 1:
+        if self.batch_size > 0 and count.max() > 1:
             graph = self.repeat_interleave(count)
             index_order = index.argsort()
             order = torch.zeros_like(index)


### PR DESCRIPTION
Fixes #83 

For the future, I think that for the property optimization, it would be even better if `max_resample` can be controlled by the user.
Maybe having an optional `task_kwargs` that defaults to `{}` could be passed to `GCPNGeneration` and specify hyperparameters for the  property optimization.