### PR TITLE
fix: RuntimeError in GraphIsomorphismNetwork #92

### DIFF
--- a/torchdrug/models/chebnet.py
+++ b/torchdrug/models/chebnet.py
@@ -35,7 +35,7 @@ class ChebyshevConvolutionalNetwork(nn.Module, core.Configurable):
         if not isinstance(hidden_dims, Sequence):
             hidden_dims = [hidden_dims]
         self.input_dim = input_dim
-        self.output_dim = hidden_dims[-1] * (len(hidden_dims) if concat_hidden else 1)
+        self.output_dim = sum(hidden_dims) if concat_hidden else hidden_dims[-1]
         self.dims = [input_dim] + list(hidden_dims)
         self.short_cut = short_cut
         self.concat_hidden = concat_hidden

--- a/torchdrug/models/gat.py
+++ b/torchdrug/models/gat.py
@@ -35,7 +35,7 @@ class GraphAttentionNetwork(nn.Module, core.Configurable):
         if not isinstance(hidden_dims, Sequence):
             hidden_dims = [hidden_dims]
         self.input_dim = input_dim
-        self.output_dim = hidden_dims[-1] * (len(hidden_dims) if concat_hidden else 1)
+        self.output_dim = sum(hidden_dims) if concat_hidden else hidden_dims[-1]
         self.dims = [input_dim] + list(hidden_dims)
         self.short_cut = short_cut
         self.concat_hidden = concat_hidden

--- a/torchdrug/models/gcn.py
+++ b/torchdrug/models/gcn.py
@@ -33,7 +33,7 @@ class GraphConvolutionalNetwork(nn.Module, core.Configurable):
         if not isinstance(hidden_dims, Sequence):
             hidden_dims = [hidden_dims]
         self.input_dim = input_dim
-        self.output_dim = hidden_dims[-1] * (len(hidden_dims) if concat_hidden else 1)
+        self.output_dim = sum(hidden_dims) if concat_hidden else hidden_dims[-1]
         self.dims = [input_dim] + list(hidden_dims)
         self.short_cut = short_cut
         self.concat_hidden = concat_hidden

--- a/torchdrug/models/gin.py
+++ b/torchdrug/models/gin.py
@@ -37,7 +37,7 @@ class GraphIsomorphismNetwork(nn.Module, core.Configurable):
         if not isinstance(hidden_dims, Sequence):
             hidden_dims = [hidden_dims]
         self.input_dim = input_dim
-        self.output_dim = hidden_dims[-1] * (len(hidden_dims) if concat_hidden else 1)
+        self.output_dim = sum(hidden_dims) if concat_hidden else hidden_dims[-1]
         self.dims = [input_dim] + list(hidden_dims)
         self.short_cut = short_cut
         self.concat_hidden = concat_hidden


### PR DESCRIPTION
This pull request fixes issue #92 and related issues of other predictors, which are tested by the following script:

```python
import torch
from torchdrug import data, datasets

dataset = datasets.ClinTox("~/molecule-datasets/")
lengths = [int(0.8 * len(dataset)), int(0.1 * len(dataset))]
lengths += [len(dataset) - sum(lengths)]
train_set, valid_set, test_set = torch.utils.data.random_split(dataset, lengths)

from torchdrug import core, models, tasks, utils

for each_model in ['GIN', 'ChebNet', 'GAT', 'GCN']:
    model = getattr(models, each_model)(input_dim=dataset.node_feature_dim,
                       hidden_dims=[128, 192],
                       short_cut=True, batch_norm=True, concat_hidden=True)
    task = tasks.PropertyPrediction(model, task=dataset.tasks,
                                    criterion="bce", metric=("auprc", "auroc"))

    optimizer = torch.optim.Adam(task.parameters(), lr=4e-4)
    solver = core.Engine(task, train_set, valid_set, test_set, optimizer,
                         batch_size=1024)
    solver.train(num_epoch=10)
    solver.evaluate("valid")
```