### PR TITLE
Handling case where all molecules are invalid in property optimization

### DIFF
--- a/torchdrug/tasks/generation.py
+++ b/torchdrug/tasks/generation.py
@@ -19,10 +19,7 @@ from torchdrug import layers
 
 logger = logging.getLogger(__name__)
 
-TASK_TO_STR = {
-    'qed': 'QED',
-    'plogp': 'Penalized logP'
-}
+
 @R.register("tasks.AutoregressiveGeneration")
 class AutoregressiveGeneration(tasks.Task, core.Configurable):
     """
@@ -147,14 +144,18 @@ class AutoregressiveGeneration(tasks.Task, core.Configurable):
         if len(graph) == 0 or graph.num_nodes.max() == 1:
             logger.error("Generation results collapse to singleton molecules")
 
-            # Imitate return variables
-            all_loss.requires_grad = True
+            all_loss.requires_grad_()
+            nan = torch.tensor(float("nan"), device=self.device)
             for task in self.task:
-                metric.update({
-                    TASK_TO_STR.get(task, task): torch.tensor(0.),
-                    f'{TASK_TO_STR.get(task, task)} (max)': torch.tensor(0.),
-                })
-            metric.update({'PPO objective': all_loss})
+                if task == "plogp":
+                    metric["Penalized logP"] = nan
+                    metric["Penalized logP (max)"] = nan
+                elif task == "qed":
+                    metric["QED"] = nan
+                    metric["QED (max)"] = nan
+            metric["node PPO objective"] = nan
+            metric["edge PPO objective"] = nan
+
             return all_loss, metric
 
         reward = torch.zeros(len(graph), device=self.device)
@@ -819,14 +820,17 @@ class GCPNGeneration(tasks.Task, core.Configurable):
         if len(graph) == 0 or graph.num_nodes.max() == 1:
             logger.error("Generation results collapse to singleton molecules")
 
-            # Imitate return variables
-            all_loss.requires_grad = True
+            all_loss.requires_grad_()
+            nan = torch.tensor(float("nan"), device=self.device)
             for task in self.task:
-                metric.update({
-                    TASK_TO_STR.get(task, task): torch.tensor(0.),
-                    f'{TASK_TO_STR.get(task, task)} (max)': torch.tensor(0.),
-                })
-            metric.update({'PPO objective': all_loss})
+                if task == "plogp":
+                    metric["Penalized logP"] = nan
+                    metric["Penalized logP (max)"] = nan
+                elif task == "qed":
+                    metric["QED"] = nan
+                    metric["QED (max)"] = nan
+            metric["PPO objective"] = nan
+
             return all_loss, metric
 
         reward = torch.zeros(len(graph), device=self.device)


### PR DESCRIPTION
Currently (with the current code on `master`), if one runs the property optimization and the model produces only one *unique* molecule, we get this error:

```sh
torchdrug/torchdrug/tasks/generation.py", line 147, in reinforce_forward
    raise ValueError("Generation results collapse to singleton molecules")
ValueError: Generation results collapse to singleton molecules
```

Moreover, when we have **only** invalid molecules, we get another error:

```sh
torchdrug/torchdrug/tasks/generation.py", line 809, in reinforce_forward
    if graph.num_nodes.max() == 1:
RuntimeError: max(): Expected reduction dim to be specified for input.numel() == 0. Specify the reduction dim with the 'dim' argument.

```

Conceptually, the error is basically the same as reported in #83 (which was fixed in #84). But this time, the affected part is the property optimization, not in the training.

**SOLUTION**:
Basically, what I'm doing in this PR is imitating the two return variables of `reinforce_forward` whenever the number of generated molecules is 0 or 1. 

Please have a look @KiddoZhu 

