### PR TITLE
Depend on matplotlib-base conda package

### DIFF
--- a/conda/torchdrug/meta.yaml
+++ b/conda/torchdrug/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - decorator
     - numpy >=1.11
     - rdkit >=2020.09
-    - matplotlib
+    - matplotlib-base
     - tqdm
     - networkx
     - ninja


### PR DESCRIPTION
If you don't need to depend on the PyQT libraries, then it should use the matplotlib-base package.

See https://conda-forge.org/docs/maintainer/knowledge_base.html#matplotlib