### PR TITLE
Apple Silicon installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ We need at least PyTorch >=1.13 `arm64` installed natively (via conda or pip). U
 
 ```bash
 pip install --no-cache-dir torch==1.13.0
-pip install git+https://github.com/rusty1s/pytorch_sparse.git
 pip install git+https://github.com/rusty1s/pytorch_scatter.git
 pip install git+https://github.com/rusty1s/pytorch_cluster.git
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Import-VisualStudioVars -Architecture x64
 $env:LIB += ";C:\Program Files\Python37\libs"
 ```
 
+### Apple Silicon (M1/M2) ###
+
+We need at least PyTorch >=1.13 `arm64` installed natively (via conda or pip). Until `torch-scatter` and `torch-cluster` have `arm64` wheels, they can be compiled from the sources. See more details in the respective [issue](https://github.com/rusty1s/pytorch_scatter/issues/241).
+
+```bash
+pip install --no-cache-dir torch==1.13.0
+pip install git+https://github.com/rusty1s/pytorch_sparse.git
+pip install git+https://github.com/rusty1s/pytorch_scatter.git
+pip install git+https://github.com/rusty1s/pytorch_cluster.git
+
+pip install torchdrug
+```
+
+TorchDrug will run on Apple Silicon CPU, but the `mps` device will not work as some TorchDrug-specific tensor operations are not yet implemented for `mps`.
+
 Quick Start
 -----------
 

--- a/README.md
+++ b/README.md
@@ -78,19 +78,18 @@ Import-VisualStudioVars -Architecture x64
 $env:LIB += ";C:\Program Files\Python37\libs"
 ```
 
-### Apple Silicon (M1/M2) ###
+### Apple Silicon (M1/M2 Chips) ###
 
-We need at least PyTorch >=1.13 `arm64` installed natively (via conda or pip). Until `torch-scatter` and `torch-cluster` have `arm64` wheels, they can be compiled from the sources. See more details in the respective [issue](https://github.com/rusty1s/pytorch_scatter/issues/241).
+We need PyTorch >= 1.13 to run TorchDrug on Apple silicon. For `torch-scatter` and
+`torch-cluster`, they can be compiled from their sources. Note TorchDrug doesn't
+support `mps` devices.
 
 ```bash
-pip install --no-cache-dir torch==1.13.0
+pip install torch==1.13.0
 pip install git+https://github.com/rusty1s/pytorch_scatter.git
 pip install git+https://github.com/rusty1s/pytorch_cluster.git
-
 pip install torchdrug
 ```
-
-TorchDrug will run on Apple Silicon CPU, but the `mps` device will not work as some TorchDrug-specific tensor operations are not yet implemented for `mps`.
 
 Quick Start
 -----------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -85,3 +85,17 @@ The above commands should be executed for every PowerShell session. To setup thi
 for all PowerShell sessions, we can write them to the PowerShell profile. The
 profile can be found by the ``$profile`` command in PowerShell. You may need to
 create the profile if you use it for the first time.
+
+Apple Silicon (M1/M2 Chips)
+---------------------------
+
+PyTorch supports Apple silicon from version 1.13. While `torch-scatter` and `torch-cluster` don't have pre-compiled binaries for Apple silicon, we can compile them from their sources. See https://github.com/rusty1s/pytorch_scatter/issues/241 for more details.
+
+.. code:: bash
+
+	pip install torch==1.13.0
+	pip install git+https://github.com/rusty1s/pytorch_scatter.git
+	pip install git+https://github.com/rusty1s/pytorch_cluster.git
+	pip install torchdrug
+
+Note TorchDrug runs on Apple silicon CPUs, but doesn't support `mps` devices.


### PR DESCRIPTION
Finally managed to run TorchDrug on M2 Max, with PyTorch 1.13 should be relatively straightforward, just need to compile `torch-scatter` and `torch-cluster` from the master branch until `arm64` wheels become widely available.

The CPU version works fine, the GPU version with the `mps` device won't work because some `int64` operations used in TorchDrug are still not supported in the `mps` backend. Hopefully PyTorch 2.0 brings support of more tensor ops for `mps`