### PR TITLE
fix: broken nvidia apt keys in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,9 @@ LABEL org.opencontainers.image.source = "https://github.com/DeepGraphLearning/to
 LABEL org.opencontainers.image.licenses = "Apache License 2.0"
 LABEL org.opencontainers.image.base.name="docker.io/pytorch/pytorch:1.8.1-cuda11.1-cudnn8-devel"
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 RUN apt-get update && \
     apt-get install -y libxrender1 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Building the docker image was failing. 

https://github.com/NVIDIA/nvidia-docker/issues/1632