### PR TITLE
#236 Issue in atom2valence Solved

### DIFF
--- a/torchdrug/data/molecule.py
+++ b/torchdrug/data/molecule.py
@@ -518,7 +518,7 @@ class Molecule(Graph):
         """A coarse implementation of valence check."""
         # TODO: cross-check by any domain expert
         atom2valence = torch.tensor(float("nan")).repeat(constant.NUM_ATOM)
-        for k, v in self.atom2valence:
+        for k, v in self.atom2valence.items():
             atom2valence[k] = v
         atom2valence = torch.as_tensor(atom2valence, device=self.device)
 


### PR DESCRIPTION
Resolved a TypeError in the ` Molecule.is_valid ` method by correctly iterating over the atom2valence dictionary using the ` .items() ` method. This ensures proper unpacking of key-value pairs, allowing the method to perform valence checks as intended.
